### PR TITLE
Update copilot instructions for delete usage

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,6 +70,7 @@ native int BossHUD_GetBossHealth(int bossEnt);  // Natives with plugin prefix
 - **CRITICAL**: All SQL queries must be asynchronous using methodmaps
 - **GOOD**: No need to check for null when using `delete`
 - **GOOD**: Use `delete` for CloseHandle and set to null
+- **GOOD**: Use `delete` directly without checking if it's null before delete
 
 ### Performance Best Practices
 - Minimize timer usage where possible


### PR DESCRIPTION
Added a guideline to use 'delete' directly without null check.